### PR TITLE
When you try to log in into wallet, you are choosing, wallet "Select …

### DIFF
--- a/src/app/modules/login/login.html
+++ b/src/app/modules/login/login.html
@@ -1,86 +1,89 @@
-<div class="login-page">
-  <div class="container">
-    <div class="row text-center">
-      <div class="col-md-12">
-        <h1>{{ 'LOGIN_MEMBER_TITLE' | translate }}</h1>
-      </div>
-    </div>
+<form ng-submit="$ctrl.login($ctrl.selectedWallet)">
 
-    <div class="row">
-      <div class="col-md-6 col-md-offset-3">
-        <div class="form-group">
-          <div class="input-group">
-            <span class="input-group-btn">
-              <label for="namespaceParent" class="control-label">{{ 'LOGIN_SELECT_WALLET_YOURS' | translate }}: </label>
-            </span>
-            <select class="form-control" ng-model="$ctrl.selectedWallet" ng-options="wallet.name group by (wallet.accounts[0].network | toNetworkName) for wallet in $ctrl._storage.wallets">
-              <option value="" disabled selected>{{ 'LOGIN_SELECT_WALLET' | translate }}</option>
-            </select>
+  <div class="login-page">
+    <div class="container">
+      <div class="row text-center">
+        <div class="col-md-12">
+          <h1>{{ 'LOGIN_MEMBER_TITLE' | translate }}</h1>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+          <div class="form-group">
+            <div class="input-group">
+              <span class="input-group-btn">
+                <label for="namespaceParent" class="control-label">{{ 'LOGIN_SELECT_WALLET_YOURS' | translate }}: </label>
+              </span>
+              <select class="form-control" ng-model="$ctrl.selectedWallet" ng-options="wallet.name group by (wallet.accounts[0].network | toNetworkName) for wallet in $ctrl._storage.wallets">
+                <option value="" disabled selected>{{ 'LOGIN_SELECT_WALLET' | translate }}</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="input-group">
+              <span class="input-group-btn">
+                <label>{{ 'FORM_PASSWORD' | translate }}: </label>
+              </span>
+              <input class="form-control" type="password" ng-model="$ctrl.common.password" placeholder="{{ 'FORM_PASSWORD_FIELD_PLACEHOLDER' | translate }}"/>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row loginButtons">
+        <div class="col-md-3 col-md-offset-3 col-sm-6">
+          <button class="btn btn-lg btn-success btn-block"
+                type="submit" ng-disabled="!$ctrl.selectedWallet">
+                {{ 'LOGIN_LOGIN_BUTTON' | translate }}
+          </button>
+        </div>
+        <div class="col-md-3 col-sm-6">
+          <div class="form-group">
+            <div type="button" class="fileUpload btn btn-lg btn-block btn-import">
+              <span>{{ 'LOGIN_IMPORT_BUTTON' | translate }}</span>
+              <input type="file" class="upload" multiple='multiple' read-wallet-files="$ctrl.loadWallet($fileContent, $isNCC)" />
+            </div>
           </div>
         </div>
 
-        <div class="form-group">
-          <div class="input-group">
-            <span class="input-group-btn">
-              <label>{{ 'FORM_PASSWORD' | translate }}: </label>
-            </span>
-            <input class="form-control" type="password" ng-model="$ctrl.common.password" placeholder="{{ 'FORM_PASSWORD_FIELD_PLACEHOLDER' | translate }}"/>
-          </div>
-        </div>
       </div>
-    </div>
 
-    <div class="row loginButtons">
-      <div class="col-md-3 col-md-offset-3 col-sm-6">
-        <button class="btn btn-lg btn-success btn-block"
-              type="submit" ng-click="$ctrl.login($ctrl.selectedWallet)" ng-disabled="!$ctrl.selectedWallet">
-              {{ 'LOGIN_LOGIN_BUTTON' | translate }}
+    </div>
+    <a id="downloadWallet" target="_blank"></a>
+  </div>
+
+
+
+  <!-- Upgrade account Modal -->
+  <div id="upgradeWallet" class="modal fade" role="dialog">
+    <div class="modal-dialog">
+
+      <!-- Modal content-->
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h4 class="modal-title">{{ 'LOGIN_UPGRADE_TITLE' | translate }}</h4>
+        </div>
+        <p class="bg-danger">
+          <i class="fa fa-exclamation-triangle"></i> <span ng-bind-html="'LOGIN_UPGRADE_MESSAGE' | translate"></span>
+        </p>
+        <div class="modal-body">
+        <fieldset class="form-group">
+          <input class="form-control form-control-lg"
+            type="password"
+            placeholder="{{ 'FORM_PASSWORD_FIELD_PLACEHOLDER' | translate }}"
+            ng-model="$ctrl.common.password"/>
+        </fieldset>
+
+        <button class="btn btn-success"
+        type="submit" ng-disabled="$ctrl.okPressed || !$ctrl.common.password.length" ng-click="$ctrl.upgradeWallet()">
+        {{ 'LOGIN_UPGRADE_BUTTON' | translate }}
         </button>
-      </div>
-      <div class="col-md-3 col-sm-6">
-        <div class="form-group">
-          <div type="button" class="fileUpload btn btn-lg btn-block btn-import">
-            <span>{{ 'LOGIN_IMPORT_BUTTON' | translate }}</span>
-            <input type="file" class="upload" multiple='multiple' read-wallet-files="$ctrl.loadWallet($fileContent, $isNCC)" />
-          </div>
         </div>
       </div>
 
     </div>
-
   </div>
-  <a id="downloadWallet" target="_blank"></a>
-</div>
-
-
-
-<!-- Upgrade account Modal -->
-<div id="upgradeWallet" class="modal fade" role="dialog">
-  <div class="modal-dialog">
-
-    <!-- Modal content-->
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title">{{ 'LOGIN_UPGRADE_TITLE' | translate }}</h4>
-      </div>
-      <p class="bg-danger">
-        <i class="fa fa-exclamation-triangle"></i> <span ng-bind-html="'LOGIN_UPGRADE_MESSAGE' | translate"></span>
-      </p>
-      <div class="modal-body">
-      <fieldset class="form-group">
-        <input class="form-control form-control-lg"
-          type="password"
-          placeholder="{{ 'FORM_PASSWORD_FIELD_PLACEHOLDER' | translate }}"
-          ng-model="$ctrl.common.password"/>
-      </fieldset>
-
-      <button class="btn btn-success"
-      type="submit" ng-disabled="$ctrl.okPressed || !$ctrl.common.password.length" ng-click="$ctrl.upgradeWallet()">
-      {{ 'LOGIN_UPGRADE_BUTTON' | translate }}
-      </button>
-      </div>
-    </div>
-
-  </div>
-</div>
+</form>


### PR DESCRIPTION
…Wallet", next you are typing the password, but you can't hit "Sign In" button just by pressing "Enter" on keyboard, you have to do it by mouse.

this is now fixed by wrapping the login form in a form with a ng-submit call in it. The button has no more ng-click since the submit button already triggers ng-submit. The form follows the original button ng-click method, thus no functionality is lost

referenced issue: https://github.com/NemProject/NanoWallet/issues/134

wallet address: NCXHFT-PJQMNW-2EBVG6-UVAP66-3PYNBS-2YJ6GD-4I6V