### PR TITLE
set English to the default fallback language

### DIFF
--- a/src/app/modules/languages/index.js
+++ b/src/app/modules/languages/index.js
@@ -25,4 +25,9 @@ app.config(JapaneseProvider);
 import RussianProvider from './ru';
 app.config(RussianProvider);
 
+// comment this while developing to see untranslated strings
+app.config(['$translateProvider', function($translateProvider) {
+    $translateProvider.fallbackLanguage('en');
+}]);
+
 export default app;


### PR DESCRIPTION
If no translation string is found in the current selected language, it from now on looks for the English version. This improves development where a developer only needs to focus on providing English versions, where translators can catch-up with the other languages.

wallet address NCXHFTPJQMNW2EBVG6UVAP663PYNBS2YJ6GD4I6V