### PR TITLE
The bottom half of the "Import Wallet" button doesn't open the file dialog

### DIFF
--- a/src/sass/_new.scss
+++ b/src/sass/_new.scss
@@ -422,8 +422,7 @@ fieldset .form-control.has-error {
   input.upload {
     position: absolute;
     top: 0;
-    margin: 0;
-    padding: 0;
+    padding: 0 0 0 100%;
     font-size: 20px;
     cursor: pointer;
     opacity: 0;
@@ -469,11 +468,13 @@ i.fa-question-circle-o, i.fa-question {
     overflow: hidden;
 }
 .fileUpload input.upload {
+    width: 100%;
+    height: 100%;
     position: absolute;
     top: 0;
     right: 0;
     margin: 0;
-    padding: 0;
+    padding: 0 0 0 100%;
     font-size: 20px;
     cursor: pointer;
     opacity: 0;


### PR DESCRIPTION
## Expected Behavior
If I click on the bottom half of the file dialog, the file dialog should be opened.

## Current Behavior
If I click on the bottom half of the file dialog nothing happens.
![wallet-import-button](https://user-images.githubusercontent.com/307006/28086703-2cedb772-6680-11e7-9e44-735ed2557cf0.png)


## Possible Solution
The `input` element with the `upload` class has an height of  29px, whereby the button itself has an height of 46px. So the input field should have an height of 100% so that it fills the complete parent element.

## Steps to Reproduce
1. Click on the bottom half of the "Import Wallet" button

## Details
Bounty address: NCZ7JL-IG2PVY-JGN7IN-HS65TB-SW66AT-4INETE-TUGJ