### PR TITLE
Update nw.js to 0.25.0 and nw-builder to 3.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ build/Release
 # App builds
 dist
 cache
+build
 
 # Dependency directories
 node_modules

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ gulp.task('views', function() {
 // Build App
 gulp.task('app', function () {
     var nw = new NwBuilder({
-        version: '0.14.6',
+        version: '0.25.0',
         files: './build/**',
         buildDir: './dist',
         buildType: 'versioned',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "gulp-notify": "^2.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.3",
-    "gulp-util": "^3.0.7",
     "bootstrap": "3.3.7",
     "jquery": "3.0.0",
     "marked": "^0.3.5",
@@ -35,8 +34,8 @@
     "gulp-autoprefixer": "^3.1.1",
     "gulp-sass": "^3.0.0",
     "gulp-util": "^3.0.8",
-    "nw": "^0.20.1",
-    "nw-builder": "^3.1.3",
+    "nw": "^0.25.0",
+    "nw-builder": "^3.4.1",
     "zxcvbn": "4.4.2"
   },
   "directories": {


### PR DESCRIPTION
The current nw.js version has an issue with the file open dialog. It shoes squares instead of the correct font on Arch linux based systems. Updating the version to 0.25.0 fixes this issue.

I've also removed "gulp-util": "^3.0.7" from package.json because "gulp-util": "^3.0.8" is already contained.

I've issues building the windows version on my Linux system. It seems that I hit [this issue](https://github.com/nwjs-community/nw-builder/issues/179). Maybe someone with a running build system can test if the new nw.js version can be build for all platforms.

Fixes: https://github.com/NemProject/NanoWallet/issues/193