### PR TITLE
Suggestion for fixing hardcoded market info (NanoWallet 2.x) - issue #393

### DIFF
--- a/src/app/layout/partials/marketData.html
+++ b/src/app/layout/partials/marketData.html
@@ -3,22 +3,22 @@
   <h4> {{ 'DASHBOARD_MARKET_INFO_TITLE' | translate }} <i class="fa fa-refresh" style="cursor:pointer;float:right;" ng-click="$ctrl.refreshMarketInfo();"></i></h4>
   <div class="row">
     <div class="col-md-6 col-sm-3 header">
-      {{ 'DASHBOARD_MARKET_INFO_CAP' | translate }} in {{ $ctrl.selectedMarket }}:
+      {{ 'DASHBOARD_MARKET_INFO_CAP' | translate }} ({{ $ctrl.selectedMarket }}):
       <br>
       <span> {{($ctrl._DataStore.market.xem.highestBid * 8999999999) * $ctrl._DataStore.market.btc[$ctrl.selectedMarket].last | currencyFormat}}</span>
     </div>
     <div class="col-md-6 col-sm-3 header">
-      {{ 'DASHBOARD_MARKET_INFO_VOLUME' | translate }} in {{ $ctrl.selectedMarket }}:
+      {{ 'DASHBOARD_MARKET_INFO_VOLUME' | translate }} ({{ $ctrl.selectedMarket }}):
       <br>
       <span> {{$ctrl._DataStore.market.xem.baseVolume * $ctrl._DataStore.market.btc[$ctrl.selectedMarket].last | currencyFormat}}</span>
     </div>
     <div class="col-md-6 col-sm-3 header ticker">
-      {{ 'DASHBOARD_MARKET_INFO_PRICE' | translate }} in {{ $ctrl.selectedMarket }}:
+      {{ 'DASHBOARD_MARKET_INFO_PRICE' | translate }} ({{ $ctrl.selectedMarket }}):
       <br>
       <span>{{$ctrl._Helpers.toFixed4($ctrl._DataStore.market.xem.highestBid * $ctrl._DataStore.market.btc[$ctrl.selectedMarket].last)}}</span>
     </div>
     <div class="col-md-6 col-sm-3 ticker header">
-      {{ 'DASHBOARD_MARKET_INFO_PRICE' | translate }} in Bitcoin:
+      {{ 'DASHBOARD_MARKET_INFO_PRICE' | translate }} (Bitcoin):
       <br>
       <span><i class="fa fa-bitcoin"></i> {{$ctrl._DataStore.market.xem.highestBid}}</span>
     </div>


### PR DESCRIPTION
On Market info section there are harcoded english words "in" on several places , e.g. "in USD" and "in Bitcoin", as you can see in this screenshot:
![now-market-info](https://user-images.githubusercontent.com/34668068/34367617-23cc47b0-eaad-11e7-83f6-666d2fdca0a9.PNG)

I have removed the "in" words, and print out ctrl.selectedMarket selection in brackets:
![fix-market-info](https://user-images.githubusercontent.com/34668068/34367624-4284db22-eaad-11e7-92bf-b4cb78e3e781.PNG)

Brackets are picked as option so they would't interfere with existing languages, and be universal.
in USD => (USD)
in Bitcoin => (Bitcoin)
Also brackets are used in Percentage change, so they fit in perfectly.

NEM bounty/donation address:
NCIG52B3J4MSSCDAY4JIUSPUUMMKDIWLYAYAPVQZ
