### PR TITLE
Suggestion for "Enhancement Request: Node Cicrle Color"

### DIFF
--- a/src/app/layout/header.html
+++ b/src/app/layout/header.html
@@ -57,7 +57,7 @@
         </li>
         <li class="node" style="cursor:pointer;">
           <a data-toggle="modal" data-target=".nodes" aria-haspopup="true" aria-expanded="false" show-authed="true">
-            <i class="fa fa-circle-o" ng-style="$ctrl._DataStore.connection.status ? {'color': 'green'} : {'color': 'red'}"></i> {{ 'HEADER_NODE' | translate }}
+            <i class="fa fa-circle" ng-style="$ctrl._DataStore.connection.status ? {'color': '#00b300'} : {'color': 'red'}"></i> {{ 'HEADER_NODE' | translate }}
           </a>
         </li>
         <li class="account" ng-show="$ctrl._DataStore.account.metaData.account">


### PR DESCRIPTION
Suggestion for "Enhancement Request: Node Cicrle Color" Issue #389 

I have made a pretty simple change, replacing fontawsome class "fa-circle-o" with "fa-circle" which is filled, and changed the green color to a bit brighter one (hex code: 00b300, used as color for little paper airplane under transactions).

Here are screenshots of changed circles:
![green](https://user-images.githubusercontent.com/34668068/34465223-2e76ad12-eea5-11e7-911e-53669cf9c228.png)
![red](https://user-images.githubusercontent.com/34668068/34465226-640295f4-eea5-11e7-9209-ae2b76b9180e.png)

Donation address:
NCIG52B3J4MSSCDAY4JIUSPUUMMKDIWLYAYAPVQZ