### PR TITLE
Feature: Added support for 10 Trezor accounts

### DIFF
--- a/src/app/modules/languages/en.js
+++ b/src/app/modules/languages/en.js
@@ -785,6 +785,7 @@ function EnglishProvider($translateProvider) {
         TREZOR_TITLE: 'TREZOR',
         TREZOR_TEXT: 'The TREZOR hardware wallet allows you to secure your XEM, mosaics and multisig accounts',
         TREZOR_BUTTON: 'Login with TREZOR',
+		TREZOR_SELECT_ACCOUNT: 'Select an account',
 
         // CREATE OFFLINE TRANSACTION MODULE
         OFFLINE_TX_TITLE: 'Prepare an offline transaction',

--- a/src/app/modules/languages/nl.js
+++ b/src/app/modules/languages/nl.js
@@ -784,6 +784,7 @@ function DutchProvider($translateProvider) {
         TREZOR_TITLE: 'TREZOR',
         TREZOR_TEXT: 'De TREZOR hardware portemonnee maakt veilig werken met XEM, Mozaïeken en Multi-handtekening accounts mogelijk',
         TREZOR_BUTTON: 'Aanmelden met TREZOR',
+	TREZOR_SELECT_ACCOUNT: 'Selecteer een account',
 
         // CREATE OFFLINE TRANSACTION MODULE
         OFFLINE_TX_TITLE: 'Bereid een offline transactie voor',

--- a/src/app/modules/trezor/trezor.controller.js
+++ b/src/app/modules/trezor/trezor.controller.js
@@ -106,7 +106,7 @@ class TrezorCtrl {
      * Login with TREZOR
      */
     login() {
-        this._Trezor.createWallet(this.network).then((wallet) => {
+        this._Trezor.createWallet(this.network, this.account).then((wallet) => {
             this._Login.login({}, wallet);
         }, (error) => {
             this._$timeout(() => {

--- a/src/app/modules/trezor/trezor.controller.js
+++ b/src/app/modules/trezor/trezor.controller.js
@@ -21,7 +21,22 @@ class TrezorCtrl {
         //// End dependencies region ////
 
         //// Module properties region ////
-
+        /**
+         * List of accounts
+         */        
+		var allAccounts = {
+		    0: "#1",
+		    1: "#2",
+		    2: "#3",
+		    3: "#4",
+		    4: "#5",
+		    5: "#6",
+		    6: "#7",
+		    7: "#8",
+		    8: "#9",
+		    9: "#10"
+		};
+        
         /**
          * Default network
          *
@@ -36,6 +51,22 @@ class TrezorCtrl {
          */
         this.networks = nem.model.network.data;
 
+        /**
+         * Account
+         *
+         * @type {number}
+         */
+        this.account = 0;
+
+		/**
+         * All accounts available
+         *
+         * @type {object} - An object of objects
+         */        
+		this.accounts = Object.keys(allAccounts).map(function (key) {
+            return { id: key, text: allAccounts[key] };
+		});
+        
         //// End properties region ////
     }
 
@@ -62,6 +93,15 @@ class TrezorCtrl {
         this.network = id;
     }
 
+    /**
+     * Change account
+     *
+     * @param {number} id - Account id
+     */
+    changeAccount(id) {
+        this.account = id;
+    }
+    
     /**
      * Login with TREZOR
      */

--- a/src/app/modules/trezor/trezor.controller.js
+++ b/src/app/modules/trezor/trezor.controller.js
@@ -20,23 +20,7 @@ class TrezorCtrl {
 
         //// End dependencies region ////
 
-        //// Module properties region ////
-        /**
-         * List of accounts
-         */        
-		var allAccounts = {
-		    0: "#1",
-		    1: "#2",
-		    2: "#3",
-		    3: "#4",
-		    4: "#5",
-		    5: "#6",
-		    6: "#7",
-		    7: "#8",
-		    8: "#9",
-		    9: "#10"
-		};
-        
+        //// Module properties region ////        
         /**
          * Default network
          *
@@ -54,18 +38,27 @@ class TrezorCtrl {
         /**
          * Account
          *
-         * @type {number}
+         * @type {object}
          */
-        this.account = 0;
+        this.account;
 
-		/**
+	/**
          * All accounts available
          *
-         * @type {object} - An object of objects
+         * @type {array of objects}
          */        
-		this.accounts = Object.keys(allAccounts).map(function (key) {
-            return { id: key, text: allAccounts[key] };
-		});
+	this.accounts = [
+	  {id:0,text:'#1'},
+	  {id:1,text:'#2'},
+	  {id:2,text:'#3'},
+	  {id:3,text:'#4'},
+	  {id:4,text:'#5'},
+	  {id:5,text:'#6'},
+	  {id:6,text:'#7'},
+	  {id:7,text:'#8'},
+	  {id:8,text:'#9'},
+	  {id:9,text:'#10'}
+	];
         
         //// End properties region ////
     }
@@ -96,17 +89,17 @@ class TrezorCtrl {
     /**
      * Change account
      *
-     * @param {number} id - Account id
+     * @param {object}
      */
-    changeAccount(id) {
-        this.account = id;
+    changeAccount(account) {
+        this.account = account;
     }
     
     /**
      * Login with TREZOR
      */
     login() {
-        this._Trezor.createWallet(this.network, this.account).then((wallet) => {
+        this._Trezor.createWallet(this.network, this.account.id, this.account.text).then((wallet) => {
             this._Login.login({}, wallet);
         }, (error) => {
             this._$timeout(() => {

--- a/src/app/modules/trezor/trezor.html
+++ b/src/app/modules/trezor/trezor.html
@@ -23,6 +23,15 @@
         <p ng-show="$ctrl.network === -104"><span ng-bind-html="'SIGNUP_NETWORK_TESTNET' | translate"></span></p>
         <p ng-show="$ctrl.network === 96"><span ng-bind-html="'SIGNUP_NETWORK_MIJIN' | translate"></span></p>
       </div>
+      <fieldset class="form-group">
+        <p class="text-center">{{'SELECT_TREZOR_ACCOUNT' | translate}}</p>
+        <select class="form-control"
+                ng-model="$ctrl.account"
+                ng-change="$ctrl.changeAccount($ctrl.account)"
+                ng-options="account.id as account.text for account in $ctrl.accounts">
+          <option value="" disabled selected>{{'SELECT_TREZOR_ACCOUNT' | translate}}</option>
+        </select>
+      </fieldset>      
       <div class="form-group">
         <hr style="border-color:#444;">
         <div class="row">

--- a/src/app/modules/trezor/trezor.html
+++ b/src/app/modules/trezor/trezor.html
@@ -24,12 +24,12 @@
         <p ng-show="$ctrl.network === 96"><span ng-bind-html="'SIGNUP_NETWORK_MIJIN' | translate"></span></p>
       </div>
       <fieldset class="form-group">
-        <p class="text-center">{{'SELECT_TREZOR_ACCOUNT' | translate}}</p>
+        <p class="text-center">{{'TREZOR_SELECT_ACCOUNT' | translate}}</p>
         <select class="form-control"
                 ng-model="$ctrl.account"
                 ng-change="$ctrl.changeAccount($ctrl.account)"
                 ng-options="account.id as account.text for account in $ctrl.accounts">
-          <option value="" disabled selected>{{'SELECT_TREZOR_ACCOUNT' | translate}}</option>
+          <option value="" disabled selected>{{'TREZOR_SELECT_ACCOUNT' | translate}}</option>
         </select>
       </fieldset>      
       <div class="form-group">

--- a/src/app/modules/trezor/trezor.html
+++ b/src/app/modules/trezor/trezor.html
@@ -28,7 +28,7 @@
         <select class="form-control"
                 ng-model="$ctrl.account"
                 ng-change="$ctrl.changeAccount($ctrl.account)"
-                ng-options="account.id as account.text for account in $ctrl.accounts">
+                ng-options="account as account.text for account in $ctrl.accounts track by account.id">
           <option value="" disabled selected>{{'TREZOR_SELECT_ACCOUNT' | translate}}</option>
         </select>
       </fieldset>      
@@ -44,5 +44,4 @@
       </div>
     </div>
   </div>
-
 </div>

--- a/src/app/modules/trezor/trezor.service.js
+++ b/src/app/modules/trezor/trezor.service.js
@@ -22,8 +22,8 @@ class Trezor {
 
     // Service methods region //
 
-    createWallet(network) {
-        return this.createAccount(network, 0, "Primary").then((account) => ({
+    createWallet(network, account_id) {
+        return this.createAccount(network, account_id, parseInt(account_id) + 1).then((account) => ({
             "name": "TREZOR",
             "accounts": {
                 "0": account

--- a/src/app/modules/trezor/trezor.service.js
+++ b/src/app/modules/trezor/trezor.service.js
@@ -22,8 +22,8 @@ class Trezor {
 
     // Service methods region //
 
-    createWallet(network, account_id) {
-        return this.createAccount(network, account_id, parseInt(account_id) + 1).then((account) => ({
+    createWallet(network, account_id, account_text) {
+        return this.createAccount(network, account_id, account_text).then((account) => ({
             "name": "TREZOR",
             "accounts": {
                 "0": account


### PR DESCRIPTION
Added support for 10 Trezor accounts when logging in. 

It's easier to use different accounts on a Trezor when they could be selected just before logging in. Otherwise you'll need to create extra accounts each time you login, starting with account 2, then 3, then 4, etc. So if you want to use account 5, you'll need to create 2,3,4 first.

![1](https://user-images.githubusercontent.com/16215404/44943180-5f5d2280-adc2-11e8-98ea-152c5659a3b9.png)
![2](https://user-images.githubusercontent.com/16215404/44943181-5f5d2280-adc2-11e8-9ebe-837f3b4f45d1.png)
![3](https://user-images.githubusercontent.com/16215404/44943182-5f5d2280-adc2-11e8-85b8-67fb3703c591.png)

Bounty address: please see GitHub profile information